### PR TITLE
支援新版廢土

### DIFF
--- a/generalbot.js
+++ b/generalbot.js
@@ -18,7 +18,7 @@ const { version } = require("os");
 const CNTA = require('chinese-numbers-to-arabic');
 
 
-const registry = require("prismarine-registry")("1.20")
+const registry = require("prismarine-registry")("1.18.2")
 const ChatMessage = require("prismarine-chat")(registry);
 
 function logger(logToFile = false, type = "INFO", ...args) {

--- a/generalbot.js
+++ b/generalbot.js
@@ -107,9 +107,9 @@ const bot = (() => { // createMcBot
         port: profiles[process.argv[2]].port,
         username: profiles[process.argv[2]].username,
         auth: "microsoft",
-        version: "1.20"
+        version: "1.18.2"
     })
-    const ChatMessage = require('prismarine-chat')("1.20")
+    const ChatMessage = require('prismarine-chat')("1.18.2")
     if (debug) {
         bot.on("windowOpen", async (window) => {
             //console.log(window)


### PR DESCRIPTION
廢土更新至1.21 但由於mineflayer尚未支援
且1.19~1.20的BOT登入1.21之伺服器會有報錯問題
因此將版本下調為1.18.2
雖然會無法支援部分物品 但得以讓BOT正常蓋地圖畫