### PR TITLE
讓使用者可以在 config 裡選擇是否啟動 Discord bot

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 # Version 1.0.0
 [discord_setting]                                   # Discord 設定皆用字串(用"兩邊框起來的)   !!!
+  activate = false                                   # [ true / false ] 這個不用字串。是否開啟 Discord Bot
   token = "-"                                       # Discord Bot Token
   owners= "123456789012345678"                      # Owner 目前這設定沒啥用... (或許之後會用於tag 或啥的)
   appId = "123456789012345678"                      # Discord Bot Application ID

--- a/index.js
+++ b/index.js
@@ -143,7 +143,9 @@ async function handleClose() {
   logger(true, "INFO", "CONSOLE", "Closing application...");
   botManager.stop();
   const waitingTime = 1000 + botManager.getBotNums() * 200;
-  await DiscordBotStop(waitingTime);
+  if(config.discord_setting.activate){
+    await DiscordBotStop(waitingTime);
+  }
   logger(true, "INFO", "CONSOLE", "Close finished");
   process.exit(0);
 }
@@ -158,7 +160,9 @@ function main() {
   );
   addMainProcessEventHandler();
   addConsoleEventHandler();
-  DiscordBotStart(botManager);
+  if(config.discord_setting.activate){
+    DiscordBotStart(botManager);
+  }
   process.title = "[Bot][-1] type .switch to select a bot";
   let timerdelay = 3005;
   config.account.id.forEach((id) => {


### PR DESCRIPTION
如題，
反正現在 Discord Bot 功能還蠻破的(?)，而且讓使用者能關掉 Discord bot 也比較省資源，也不需要去設定 Discord 相關的東西。